### PR TITLE
Support fitting weighted importance samples and ensure proper testing

### DIFF
--- a/.github/workflows/check+build+deploy.yml
+++ b/.github/workflows/check+build+deploy.yml
@@ -20,9 +20,9 @@ jobs:
         os: [ubuntu-latest, macos-latest]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -47,7 +47,7 @@ jobs:
     needs: check
     steps:
       - name: Checkout git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Build NABU wheel
         run: |
@@ -56,7 +56,7 @@ jobs:
           python setup.py bdist_wheel
 
       - name: Upload wheels as artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wheel
           path: ./dist/*.whl
@@ -72,7 +72,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: wheel
           merge-multiple: true
@@ -81,7 +81,7 @@ jobs:
       - name: Debug
         run: ls -l dist
 
-      - uses: pypa/gh-action-pypi-publish@v1.13.0
+      - uses: pypa/gh-action-pypi-publish@v1.14.0
         with:
          user:     ${{ secrets.TWINE_USERNAME }}
          password: ${{ secrets.TWINE_PASSWORD }}

--- a/.github/workflows/check+build+deploy.yml
+++ b/.github/workflows/check+build+deploy.yml
@@ -31,11 +31,15 @@ jobs:
         python -m pip install pytest pytest-cov
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         python -m pip install -e .
-    - name: Test with pytest
+    - name: Test the CLI script
       run: |
         nabu-fit-to-data -test -dp test/data-2020-025-transformed.npz -op test/results -e 20
         # * p(χ²) = 0.0041%, p(KS) = 19.5177%
-        pytest test/*py
+    - name: Test with pytest
+      # Run the test suite even if the CLI smoke test above failed, so both are
+      # always reported. The job still fails if either step fails.
+      if: ${{ !cancelled() }}
+      run: pytest test/*py
 
   build:
     name: Build wheel

--- a/.github/workflows/commit-messages.yaml
+++ b/.github/workflows/commit-messages.yaml
@@ -8,13 +8,15 @@ name: Check if the commit messages are well-formed
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write # required for `gh pr comment`
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
-          token: ${{ secrets.GITHUB_ACCESS_TOKEN }}
           fetch-depth: 0 # download all history across all branches
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.10.13"
       - name: Install dependencies

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -10,8 +10,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.10.13"
       - uses: pre-commit/action@v3.0.1

--- a/nabu/flow/_flow_likelihood.py
+++ b/nabu/flow/_flow_likelihood.py
@@ -78,12 +78,14 @@ class FlowLikelihood(Likelihood):
         plot_progress: str = None,
         metrics: list[callable] = None,
         log: str = None,
+        *,
+        weights: np.ndarray = None,
     ) -> dict[str, list[float]]:
         """
         Fit likelihood to the data
 
         Args:
-            dataset (``np.ndarray``): _description_
+            dataset (``np.ndarray``): training samples, shape ``(N, DoF)``.
             condition (``np.ndarray``, default ``None``): _description_
             learning_rate (``float``, default ``1e-4``): _description_
             optimizer (``str``, default ``"adam"``): _description_
@@ -96,6 +98,11 @@ class FlowLikelihood(Likelihood):
             verbose (``bool``, default ``True``): _description_
             random_seed (``int``): _description_
             plot_progress (``str``, default ``None``): _description_
+            weights (``np.ndarray``, default ``None``): keyword-only per-sample weights,
+                shape ``(N,)``. If given, the flow is fit by weighted maximum
+                likelihood, which targets the density estimated by the
+                (importance-)weighted samples and removes the need to unweight via
+                resampling. If ``None``, all samples are weighted equally.
 
         Returns:
             ``dict[str, list[float]]``:
@@ -110,6 +117,7 @@ class FlowLikelihood(Likelihood):
             key=jr.key(random_seed),
             dist=self.model,
             x=self.transform.backward(dataset),
+            weights=weights,
             L1_regularisation_coef=L1_regularisation_coef,
             L2_regularisation_coef=L2_regularisation_coef,
             condition=condition,

--- a/nabu/flow/_train.py
+++ b/nabu/flow/_train.py
@@ -42,11 +42,17 @@ class MaximumLikelihoodLoss:
     """Loss for fitting a flow with maximum likelihood (negative log likelihood).
 
     This loss can be used to learn either conditional or unconditional distributions.
+    When ``weighted`` is ``True`` the loss is the weighted mean negative log likelihood
+    :math:`-\\sum_i w_i \\log p(x_i) / \\sum_i w_i`, which targets the density that the
+    (importance-)weighted samples estimate. In that case the per-sample weights are
+    passed positionally right after ``x`` (i.e. ``(x, weights[, condition])``), so that
+    they never collide with the optional conditioning variables.
     """
 
-    def __init__(self, l1: float = 0.0, l2: float = 0.0):
+    def __init__(self, l1: float = 0.0, l2: float = 0.0, weighted: bool = False):
         self.l1 = l1
         self.l2 = l2
+        self.weighted = weighted
 
     @eqx.filter_jit
     def __call__(
@@ -54,12 +60,23 @@ class MaximumLikelihoodLoss:
         params: AbstractDistribution,
         static: AbstractDistribution,
         x: Array,
-        condition: Array = None,
+        *rest: Array,
         key: PRNGKeyArray = None,
     ) -> Float[Array, ""]:
         """Compute the loss. Key is ignored (for consistency of API)."""
+        if self.weighted:
+            weights, *condition = rest
+            condition = condition[0] if condition else None
+        else:
+            weights = None
+            condition = rest[0] if rest else None
+
         dist = unwrap(eqx.combine(params, static))
-        nll = -dist.log_prob(x, condition).mean()
+        log_prob = dist.log_prob(x, condition)
+        if weights is None:
+            nll = -log_prob.mean()
+        else:
+            nll = -jnp.sum(weights * log_prob) / jnp.sum(weights)
 
         if self.l2 != 0.0:
             nll += self.l2 * sum(jnp.sum(jnp.square(p)) for p in tree_leaves(params))
@@ -88,6 +105,8 @@ def fit(
     plot_progress: str = None,
     metrics: list[callable] = None,
     log: str = None,
+    *,
+    weights: ArrayLike = None,
 ):
     r"""Train a PyTree (e.g. a distribution) to samples from the target.
 
@@ -116,14 +135,31 @@ def fit(
         show_progress: Whether to show progress bar. Defaults to True.
         lr_scheduler: Learning rate scheduler. Defaults to None.
         plot_progress: Name of the monitoring plots. If given: plot the model once in a while to monitor progress visually. Defaults to None.
+        weights: Keyword-only per-sample weights. If given, the loss becomes the
+            weighted mean negative log likelihood, which targets the density estimated
+            by the (importance-)weighted samples. Defaults to None (unweighted).
 
     Returns:
         A tuple containing the trained distribution and the losses.
     """
-    data = (x,) if condition is None else (x, condition)
-    data = tuple(jnp.asarray(a) for a in data)
+    # Assemble the data arrays as (x[, weights][, condition]). Weights are placed
+    # right after x so the loss receives them positionally without colliding with the
+    # optional condition. train_val_split and the per-epoch shuffle permute every array
+    # with the same key, so weights stay aligned with their samples throughout.
+    arrays = [x]
+    weight_idx = None
+    if weights is not None:
+        weight_idx = len(arrays)
+        arrays.append(weights)
+    if condition is not None:
+        arrays.append(condition)
+    data = tuple(jnp.asarray(a) for a in arrays)
 
-    loss_fn = MaximumLikelihoodLoss(l1=L1_regularisation_coef, l2=L2_regularisation_coef)
+    loss_fn = MaximumLikelihoodLoss(
+        l1=L1_regularisation_coef,
+        l2=L2_regularisation_coef,
+        weighted=weights is not None,
+    )
 
     params, static = eqx.partition(
         dist,
@@ -176,9 +212,14 @@ def fit(
             batch_losses.append(loss_i)
         losses["train"].append((sum(batch_losses) / len(batch_losses)).item())
         train_summary.scalar("loss", losses["train"][-1], epoch)
+        train_metric_kwargs = (
+            {} if weight_idx is None else {"weights": train_data[weight_idx]}
+        )
         for metric in metrics:
             losses = _append_metric(
-                metric(eqx.combine(params, static), train_data[0]), losses, "train"
+                metric(eqx.combine(params, static), train_data[0], **train_metric_kwargs),
+                losses,
+                "train",
             )
 
         # Val epoch
@@ -189,9 +230,14 @@ def fit(
             batch_losses.append(loss_i)
         losses["val"].append((sum(batch_losses) / len(batch_losses)).item())
         val_summary.scalar("loss", losses["val"][-1], epoch)
+        val_metric_kwargs = (
+            {} if weight_idx is None else {"weights": val_data[weight_idx]}
+        )
         for metric in metrics:
             losses = _append_metric(
-                metric(eqx.combine(params, static), val_data[0]), losses, "val"
+                metric(eqx.combine(params, static), val_data[0], **val_metric_kwargs),
+                losses,
+                "val",
             )
 
         if lr_scheduler is not None:

--- a/nabu/flow/metrics.py
+++ b/nabu/flow/metrics.py
@@ -24,7 +24,10 @@ class GoodnessOfFit:
         self.prob_per_bin = prob_per_bin
 
     def __call__(
-        self, dist: AbstractTransformed, test_data: np.ndarray
+        self,
+        dist: AbstractTransformed,
+        test_data: np.ndarray,
+        weights: np.ndarray = None,
     ) -> dict[str, float]:
         dim = test_data.shape[-1]
         chi2_dist = np.sum(
@@ -33,5 +36,5 @@ class GoodnessOfFit:
         bins = chi2.ppf(
             np.linspace(0.0, 1.0, int(np.ceil(1.0 / self.prob_per_bin)) + 1), df=dim
         )
-        hist = Histogram(dim=dim, bins=bins, vals=chi2_dist)
+        hist = Histogram(dim=dim, bins=bins, vals=chi2_dist, weights=weights)
         return {"kstest_pvalue": hist.kstest_pval, "chi2_pvalue": hist.residuals_pvalue}

--- a/nabu/goodness_of_fit.py
+++ b/nabu/goodness_of_fit.py
@@ -2,13 +2,82 @@ import warnings
 from collections.abc import Callable, Generator, Sequence
 
 import numpy as np
-from scipy.stats import chi2, kstest, norm
+from scipy.stats import chi2, kstwo, kstwobign, norm
 
-__all__ = ["Histogram"]
+__all__ = ["Histogram", "weighted_kstest"]
 
 
 def __dir__():
     return __all__
+
+
+def weighted_kstest(
+    vals: np.ndarray,
+    cdf: Callable[[np.ndarray], np.ndarray],
+    weights: np.ndarray = None,
+) -> tuple[float, float, float]:
+    r"""
+    One-sample Kolmogorov-Smirnov test against ``cdf`` for (optionally) weighted data.
+
+    The test statistic is the supremum distance between the weighted empirical CDF
+    and ``cdf``. The p-value is computed from the Kish effective sample size
+    :math:`n_{\rm eff} = (\sum w)^2 / \sum w^2` rather than the raw number of rows:
+
+    * when all weights are equal (the unweighted case), ``n_eff`` is the integer
+      sample size and the **exact** Kolmogorov-Smirnov distribution is used, exactly
+      reproducing :func:`scipy.stats.kstest`;
+    * with non-uniform weights ``n_eff`` is generally fractional, for which no exact
+      finite-sample distribution exists, so the **asymptotic** Kolmogorov distribution
+      is used instead.
+
+    This is the appropriate test for importance samples with non-uniform weights:
+    feeding a weighted-bootstrap (resampled, hence duplicated) set into an unweighted
+    KS test violates the i.i.d. assumption and over-powers the test, because each
+    duplicated point is counted as an independent draw.
+
+    Args:
+        vals (``np.ndarray``): sample values, shape ``(N,)``.
+        cdf (``Callable``): cumulative distribution function to test against. Must be
+            vectorised over a 1d array of sorted values.
+        weights (``np.ndarray``, default ``None``): per-sample weights. If ``None``,
+            taken as ``1`` (recovering the unweighted test).
+
+    Returns:
+        ``tuple[float, float, float]``:
+        the KS statistic ``D``, the p-value, and the effective sample size.
+    """
+    vals = np.asarray(vals, dtype=float)
+    weights = np.ones_like(vals) if weights is None else np.asarray(weights, dtype=float)
+
+    if len(vals) != len(weights):
+        raise ValueError(
+            f"vals and weights must have the same length, got {len(vals)} and "
+            f"{len(weights)}"
+        )
+    if len(vals) == 0:
+        raise ValueError("vals must contain at least one sample")
+    if np.any(weights < 0.0):
+        raise ValueError("weights must be non-negative")
+    sumw = weights.sum()
+    if not sumw > 0.0:
+        raise ValueError("the total weight must be positive")
+
+    order = np.argsort(vals, kind="mergesort")
+    v, w = vals[order], weights[order]
+    ecdf_hi = np.cumsum(w) / sumw  # weighted ECDF just after each point
+    ecdf_lo = ecdf_hi - w / sumw  # weighted ECDF just before each point
+    f = cdf(v)
+    d = float(max(np.max(ecdf_hi - f), np.max(f - ecdf_lo)))
+    n_eff = float(sumw**2 / np.sum(w**2))  # Kish effective sample size
+
+    if np.allclose(w, w[0]):
+        # Equally weighted points: the effective N is the integer sample size and the
+        # exact KS distribution applies (matching scipy.stats.kstest).
+        pvalue = float(kstwo.sf(d, len(w)))
+    else:
+        # Fractional effective N: fall back to the asymptotic Kolmogorov distribution.
+        pvalue = float(kstwobign.sf(np.sqrt(n_eff) * d))
+    return d, pvalue, n_eff
 
 
 def sqrt_method(values, *args, **kwargs):
@@ -113,8 +182,18 @@ class Histogram:
     ) -> None:
         self.dim = dim
         self.vals = vals
-        self.weights = weights or np.ones(len(self.vals))
-        assert len(self.vals) == len(self.weights), "Invalid shape"
+        self.weights = (
+            np.ones(len(self.vals)) if weights is None else np.asarray(weights, float)
+        )
+        if len(self.vals) != len(self.weights):
+            raise ValueError(
+                f"vals and weights must have the same length, got {len(self.vals)} "
+                f"and {len(self.weights)}"
+            )
+        if np.any(self.weights < 0.0):
+            raise ValueError("weights must be non-negative")
+        if not np.sum(self.weights) > 0.0:
+            raise ValueError("the total weight must be positive")
 
         if isinstance(bins, int):
             assert max_val is not None, "If bins are not defined, max_val is needed"
@@ -212,10 +291,30 @@ class Histogram:
 
     @property
     def kstest_pval(self) -> float:
-        """Compute p-value for Kolmogorov-Smirnov test"""
+        """Weighted Kolmogorov-Smirnov p-value vs chi2(dim), using effective N"""
         if self._kstest is None:
-            self._kstest = kstest(self.vals, cdf=lambda x: chi2.cdf(x, df=self.dim))
-        return self._kstest.pvalue
+            self._kstest = weighted_kstest(
+                self.vals, lambda x: chi2.cdf(x, df=self.dim), self.weights
+            )
+        return self._kstest[1]
+
+    @property
+    def kstest_dval(self) -> float:
+        """Weighted Kolmogorov-Smirnov statistic D vs chi2(dim)"""
+        if self._kstest is None:
+            self._kstest = weighted_kstest(
+                self.vals, lambda x: chi2.cdf(x, df=self.dim), self.weights
+            )
+        return self._kstest[0]
+
+    @property
+    def effective_nobs(self) -> float:
+        """Kish effective sample size of the (weighted) values"""
+        if self._kstest is None:
+            self._kstest = weighted_kstest(
+                self.vals, lambda x: chi2.cdf(x, df=self.dim), self.weights
+            )
+        return self._kstest[2]
 
     @property
     def residuals_pvalue(self) -> float:

--- a/nabu/likelihood.py
+++ b/nabu/likelihood.py
@@ -10,9 +10,9 @@ import jax.numpy as jnp
 import jax.random as jr
 import numpy as np
 from jax.tree_util import tree_structure
-from scipy.stats import chi2, kstest
+from scipy.stats import chi2
 
-from .goodness_of_fit import Histogram
+from .goodness_of_fit import Histogram, weighted_kstest
 
 __all__ = ["Likelihood"]
 
@@ -115,16 +115,32 @@ class Likelihood(ABC):
         """Compute the cumulative density function at x shape (N,dof)"""
         return chi2.cdf(self.chi2(x), df=x.shape[-1])
 
-    def kstest_pvalue(self, test_dataset: np.ndarray) -> float:
-        """Compute p-value for Kolmogorov-Smirnov test"""
-        return kstest(
-            self.chi2(test_dataset), cdf=partial(chi2.cdf, df=test_dataset.shape[-1])
-        ).pvalue
+    def kstest_pvalue(
+        self, test_dataset: np.ndarray, weights: np.ndarray = None
+    ) -> float:
+        """
+        Weighted Kolmogorov-Smirnov p-value vs the chi2 distribution.
+
+        Args:
+            test_dataset (``np.ndarray``): test dataset, shape `(N, DoF)`
+            weights (``np.ndarray``, default ``None``): per-sample weights. If ``None``,
+                taken as ``1`` (recovering the unweighted test). For weighted importance
+                samples the p-value is computed from the Kolmogorov distribution using
+                the effective sample size, avoiding the over-powering that results from
+                feeding a resampled (duplicated) set into an unweighted test.
+        """
+        _, pvalue, _ = weighted_kstest(
+            self.chi2(test_dataset),
+            partial(chi2.cdf, df=test_dataset.shape[-1]),
+            weights,
+        )
+        return pvalue
 
     def goodness_of_fit(
         self,
         test_dataset: np.ndarray,
         prob_per_bin: float = 0.1,
+        weights: np.ndarray = None,
     ) -> Histogram:
         """
         Construct binned and unbinned goodness of fit test.
@@ -132,6 +148,9 @@ class Likelihood(ABC):
         Args:
             test_dataset (``np.ndarray``): test dataset, shape `(N, DoF)`
             prob_per_bin (``float``, default ``0.1``): probability of yields in each bin
+            weights (``np.ndarray``, default ``None``): per-sample weights. If ``None``,
+                taken as ``1``. Used for both the binned residuals and the (weighted)
+                Kolmogorov-Smirnov test.
 
         Returns:
             ``Histogram``:
@@ -141,21 +160,32 @@ class Likelihood(ABC):
         bins = chi2.ppf(
             np.linspace(0.0, 1.0, int(np.ceil(1.0 / prob_per_bin)) + 1), df=dim
         )
-        return Histogram(dim=dim, bins=bins, vals=self.chi2(test_dataset))
+        return Histogram(
+            dim=dim, bins=bins, vals=self.chi2(test_dataset), weights=weights
+        )
 
-    def is_valid(self, test_data: np.ndarray, threshold: float = 0.03) -> bool:
+    def is_valid(
+        self,
+        test_data: np.ndarray,
+        threshold: float = 0.03,
+        weights: np.ndarray = None,
+    ) -> bool:
         """
         Check if the likelihood is valid for a given dataset.
 
         Args:
             test_data (``np.ndarray``): Test dataset
             threshold (``float``, default ``0.03``): p-value threshold.
+            weights (``np.ndarray``, default ``None``): per-sample weights. If ``None``,
+                taken as ``1``.
 
         Returns:
             ``bool``:
             Returns `True` if the model passes the threshold.
         """
-        hist: Histogram = self.goodness_of_fit(test_dataset=test_data, prob_per_bin=0.1)
+        hist: Histogram = self.goodness_of_fit(
+            test_dataset=test_data, prob_per_bin=0.1, weights=weights
+        )
         return all(np.greater_equal([hist.residuals_pvalue, hist.kstest_pval], threshold))
 
     @abstractmethod

--- a/test/_train_TEST.py
+++ b/test/_train_TEST.py
@@ -1,0 +1,113 @@
+"""Tests for weighted maximum-likelihood training (proposal C)."""
+import equinox as eqx
+import jax.numpy as jnp
+import numpy as np
+from flowjax import wrappers
+
+from nabu.flow._flows import masked_autoregressive_flow
+from nabu.flow._train import MaximumLikelihoodLoss
+from nabu.flow.metrics import GoodnessOfFit
+
+
+def _partition(dist):
+    return eqx.partition(
+        dist,
+        eqx.is_inexact_array,
+        is_leaf=lambda leaf: isinstance(leaf, wrappers.NonTrainable),
+    )
+
+
+class TestWeightedTraining:
+    """Weighted negative-log-likelihood loss and the fit_to_data plumbing."""
+
+    def test_uniform_weights_match_unweighted_loss(self):
+        """weighted=True with unit weights reproduces the plain mean NLL."""
+        lh = masked_autoregressive_flow(dim=2, flow_layers=2, nn_width=8, random_seed=0)
+        params, static = _partition(lh.model)
+        rng = np.random.default_rng(0)
+        x = jnp.asarray(rng.normal(size=(256, 2)))
+
+        weighted = MaximumLikelihoodLoss(weighted=True)
+        unweighted = MaximumLikelihoodLoss(weighted=False)
+        assert np.isclose(
+            float(weighted(params, static, x, jnp.ones(len(x)))),
+            float(unweighted(params, static, x)),
+        )
+
+    def test_integer_weights_match_expanded_sample(self):
+        """Integer weights on unique points equal the mean NLL of the repeated sample.
+
+        This is the defining property of the weighted MLE: it removes the need to
+        unweight by physically resampling (which duplicates rows)."""
+        lh = masked_autoregressive_flow(dim=2, flow_layers=2, nn_width=8, random_seed=0)
+        params, static = _partition(lh.model)
+        rng = np.random.default_rng(1)
+        unique_x = rng.normal(size=(80, 2))
+        counts = rng.integers(1, 6, size=len(unique_x))
+        expanded = np.repeat(unique_x, counts, axis=0)
+
+        weighted = MaximumLikelihoodLoss(weighted=True)
+        unweighted = MaximumLikelihoodLoss(weighted=False)
+        loss_w = float(
+            weighted(params, static, jnp.asarray(unique_x), jnp.asarray(counts, float))
+        )
+        loss_u = float(unweighted(params, static, jnp.asarray(expanded)))
+        assert np.isclose(loss_w, loss_u, rtol=1e-5)
+
+    def test_fit_to_data_weighted_runs_with_metric(self):
+        """fit_to_data(weights=...) trains and forwards weights to the GoF metric."""
+        lh = masked_autoregressive_flow(dim=1, flow_layers=2, nn_width=8, random_seed=0)
+        rng = np.random.default_rng(2)
+        data = rng.normal(size=(400, 1))
+        weights = rng.uniform(0.2, 2.0, size=400)
+
+        history = lh.fit_to_data(
+            data,
+            weights=weights,
+            max_epochs=3,
+            batch_size=100,
+            validation_probability=0.2,
+            verbose=False,
+            metrics=[GoodnessOfFit(prob_per_bin=0.25)],
+            random_seed=0,
+        )
+        assert np.all(np.isfinite(history["train"]))
+        assert np.all(np.isfinite(history["val"]))
+        # the weighted GoF metric was recorded each epoch
+        assert "train_kstest_pvalue" in history
+        assert "val_kstest_pvalue" in history
+
+    def test_weights_is_keyword_only(self):
+        """weights must be a keyword-only argument of fit_to_data (and fit)."""
+        import inspect
+
+        from nabu.flow._flow_likelihood import FlowLikelihood
+        from nabu.flow._train import fit
+
+        for func in (FlowLikelihood.fit_to_data, fit):
+            kind = inspect.signature(func).parameters["weights"].kind
+            assert kind is inspect.Parameter.KEYWORD_ONLY, func.__qualname__
+
+    def test_weighted_fit_follows_the_weights(self):
+        """Down-weighting one mode pulls the fitted density toward the other."""
+        rng = np.random.default_rng(3)
+        pos = rng.normal(3.0, 0.3, size=(600, 1))
+        neg = rng.normal(-3.0, 0.3, size=(600, 1))
+        data = np.vstack([pos, neg])
+        # essentially switch off the negative cluster
+        weights = np.concatenate([np.ones(600), np.full(600, 1e-3)])
+
+        lh = masked_autoregressive_flow(dim=1, flow_layers=4, nn_width=16, random_seed=0)
+        lh.fit_to_data(
+            data,
+            weights=weights,
+            max_epochs=200,
+            max_patience=20,
+            batch_size=128,
+            validation_probability=0.2,
+            verbose=False,
+            random_seed=0,
+        )
+        lp_pos = float(lh.log_prob(np.array([[3.0]])))
+        lp_neg = float(lh.log_prob(np.array([[-3.0]])))
+        assert lp_pos > lp_neg, "weighted fit should favour the up-weighted mode"

--- a/test/goodness_of_fit_TEST.py
+++ b/test/goodness_of_fit_TEST.py
@@ -1,0 +1,120 @@
+"""Tests for the weighted goodness-of-fit / Kolmogorov-Smirnov test (proposal A)."""
+import numpy as np
+import pytest
+from scipy.stats import chi2, kstest
+
+from nabu.goodness_of_fit import Histogram, weighted_kstest
+
+
+def _chi2_cdf(dim):
+    return lambda x: chi2.cdf(x, df=dim)
+
+
+class TestKSTestPVal:
+    """Weighted one-sample KS test against the chi^2 distribution."""
+
+    def test_uniform_weights_match_unweighted_ks(self):
+        """With uniform weights the test reduces to scipy's exact one-sample KS."""
+        rng = np.random.default_rng(0)
+        dim = 4
+        vals = chi2.rvs(df=dim, size=5000, random_state=rng)
+
+        d, pval, n_eff = weighted_kstest(vals, _chi2_cdf(dim))
+
+        # scipy's default (exact at this N) one-sample KS is the reference: equal
+        # weights must reproduce it exactly.
+        ref = kstest(vals, _chi2_cdf(dim))
+        assert np.isclose(d, ref.statistic), "KS statistic D disagrees with scipy"
+        assert np.isclose(pval, ref.pvalue, rtol=1e-9), "p-value disagrees with scipy"
+        assert np.isclose(
+            n_eff, len(vals)
+        ), "effective N must equal N for uniform weights"
+
+    def test_none_weights_equivalent_to_ones(self):
+        """Passing ``None`` weights is identical to passing an array of ones."""
+        rng = np.random.default_rng(1)
+        vals = chi2.rvs(df=3, size=2000, random_state=rng)
+
+        assert weighted_kstest(vals, _chi2_cdf(3), None) == weighted_kstest(
+            vals, _chi2_cdf(3), np.ones(len(vals))
+        )
+
+    def test_weighted_statistic_matches_expanded_duplicates(self):
+        """Integer weights on unique points reproduce the D of the expanded sample,
+        but the p-value uses the (smaller) effective N rather than the row count."""
+        rng = np.random.default_rng(2)
+        unique_vals = chi2.rvs(df=5, size=400, random_state=rng)
+        counts = rng.integers(1, 6, size=unique_vals.shape)
+
+        expanded = np.repeat(unique_vals, counts)
+
+        d_w, p_w, n_eff = weighted_kstest(unique_vals, _chi2_cdf(5), counts)
+        ref = kstest(expanded, _chi2_cdf(5), method="asymp")
+
+        # Same empirical CDF -> identical KS statistic.
+        assert np.isclose(
+            d_w, ref.statistic
+        ), "weighted D must match the expanded-sample D"
+
+        # The effective sample size is below the number of rows whenever weights vary,
+        # so the (correct) weighted p-value is *less* significant than the over-powered
+        # unweighted test that treats every duplicated row as an independent draw.
+        assert n_eff < len(expanded)
+        assert (
+            p_w > ref.pvalue
+        ), "weighted test must be less over-powered than expanded KS"
+
+    def test_histogram_kstest_pval_uses_weights(self):
+        """Histogram.kstest_pval / kstest_dval / effective_nobs honour the weights."""
+        rng = np.random.default_rng(3)
+        dim = 4
+        vals = chi2.rvs(df=dim, size=1500, random_state=rng)
+        weights = rng.uniform(0.1, 2.0, size=vals.shape)
+
+        bins = chi2.ppf(np.linspace(0.0, 1.0, 11), df=dim)
+        hist = Histogram(dim=dim, bins=bins, vals=vals, weights=weights)
+
+        d, pval, n_eff = weighted_kstest(vals, _chi2_cdf(dim), weights)
+        assert np.isclose(hist.kstest_pval, pval)
+        assert np.isclose(hist.kstest_dval, d)
+        assert np.isclose(hist.effective_nobs, n_eff)
+        assert n_eff < len(vals), "non-uniform weights must reduce the effective N"
+
+    def test_histogram_accepts_array_weights_without_error(self):
+        """Regression: array weights previously raised an ambiguous-truth ValueError."""
+        vals = np.linspace(0.5, 20.0, 50)
+        weights = np.linspace(0.5, 1.5, 50)
+        hist = Histogram(dim=3, bins=10, vals=vals, max_val=25.0, weights=weights)
+        assert np.allclose(hist.weights, weights)
+
+    def test_invalid_inputs_raise_value_error(self):
+        """Degenerate inputs raise ValueError rather than producing NaNs."""
+        vals = np.array([1.0, 2.0, 3.0])
+
+        # length mismatch
+        with pytest.raises(ValueError):
+            weighted_kstest(vals, _chi2_cdf(2), np.ones(2))
+        # empty sample
+        with pytest.raises(ValueError):
+            weighted_kstest(np.array([]), _chi2_cdf(2))
+        # negative weight
+        with pytest.raises(ValueError):
+            weighted_kstest(vals, _chi2_cdf(2), np.array([1.0, -1.0, 1.0]))
+        # non-positive total weight
+        with pytest.raises(ValueError):
+            weighted_kstest(vals, _chi2_cdf(2), np.zeros(3))
+
+    def test_histogram_invalid_weights_raise_value_error(self):
+        """Histogram validates weights instead of asserting / dividing by zero."""
+        vals = np.linspace(0.5, 20.0, 10)
+        bins = chi2.ppf(np.linspace(0.0, 1.0, 6), df=3)
+
+        # length mismatch (previously a bare assert)
+        with pytest.raises(ValueError):
+            Histogram(dim=3, bins=bins, vals=vals, weights=np.ones(5))
+        # negative weight
+        with pytest.raises(ValueError):
+            Histogram(dim=3, bins=bins, vals=vals, weights=-np.ones(10))
+        # non-positive total weight -> would make bin_weights inf/nan
+        with pytest.raises(ValueError):
+            Histogram(dim=3, bins=bins, vals=vals, weights=np.zeros(10))

--- a/test/likelihood_TEST.py
+++ b/test/likelihood_TEST.py
@@ -1,0 +1,76 @@
+"""Tests for weighted goodness-of-fit threading in the Likelihood API (proposal B)."""
+import numpy as np
+from scipy.stats import chi2
+
+from nabu.likelihood import Likelihood
+from nabu.goodness_of_fit import weighted_kstest
+
+
+class _StubLikelihood(Likelihood):
+    """Minimal concrete Likelihood whose ``chi2`` returns precomputed values.
+
+    This isolates the goodness-of-fit threading from the flow model so the test
+    does not depend on deserialising a trained flow.
+    """
+
+    model_type = "stub"
+
+    def __init__(self, chi2_vals):
+        self._chi2_vals = np.asarray(chi2_vals, dtype=float)
+
+    def chi2(self, x):  # noqa: ARG002 - input ignored, values are precomputed
+        return self._chi2_vals
+
+    def inverse(self):
+        raise NotImplementedError
+
+    def fit_to_data(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def to_dict(self):
+        return {}
+
+
+class TestWeightedGoodnessOfFit:
+    """Likelihood.kstest_pvalue / goodness_of_fit / is_valid honour weights."""
+
+    def _setup(self, seed, dim=4, size=2000):
+        rng = np.random.default_rng(seed)
+        chi2_vals = chi2.rvs(df=dim, size=size, random_state=rng)
+        weights = rng.uniform(0.1, 2.0, size=chi2_vals.shape)
+        lh = _StubLikelihood(chi2_vals)
+        test_data = np.zeros((size, dim))  # only the trailing shape (dim) is used
+        return lh, test_data, weights, chi2_vals, dim
+
+    def test_kstest_pvalue_matches_weighted_kstest(self):
+        lh, test_data, weights, chi2_vals, dim = self._setup(0)
+        _, expected, _ = weighted_kstest(
+            chi2_vals, lambda x: chi2.cdf(x, df=dim), weights
+        )
+        assert np.isclose(lh.kstest_pvalue(test_data, weights=weights), expected)
+
+    def test_kstest_pvalue_defaults_to_unweighted(self):
+        lh, test_data, _, chi2_vals, dim = self._setup(1)
+        _, expected, _ = weighted_kstest(chi2_vals, lambda x: chi2.cdf(x, df=dim))
+        assert np.isclose(lh.kstest_pvalue(test_data), expected)
+
+    def test_goodness_of_fit_forwards_weights(self):
+        lh, test_data, weights, chi2_vals, dim = self._setup(2)
+        hist = lh.goodness_of_fit(test_data, prob_per_bin=0.1, weights=weights)
+        assert np.allclose(hist.weights, weights)
+
+        _, expected, n_eff = weighted_kstest(
+            chi2_vals, lambda x: chi2.cdf(x, df=dim), weights
+        )
+        assert np.isclose(hist.kstest_pval, expected)
+        assert np.isclose(hist.effective_nobs, n_eff)
+        assert n_eff < len(chi2_vals), "non-uniform weights must reduce the effective N"
+
+    def test_is_valid_accepts_weights(self):
+        # chi2 values genuinely drawn from chi2(dim) -> should pass a loose threshold.
+        lh, test_data, weights, _, _ = self._setup(3)
+        assert lh.is_valid(test_data, threshold=0.01, weights=weights) is True
+
+        # Shifted values are a poor fit -> should fail regardless of weights.
+        bad = _StubLikelihood(lh._chi2_vals + 8.0)
+        assert bad.is_valid(test_data, threshold=0.05, weights=weights) is False


### PR DESCRIPTION
- b58fa719819c47371427e5d8eb364ca0960c9a68 Add functions for a weighted KS test. Also fix the ``Histogram`` class for a bug causing a silent test case failure down the line.
- 67acfc8de54ad0bad8d999635372eb0ce39f1d7d Forward sample weights throughout most of the API, in preparation for fitting weighted importance samples.
- 26eb5111b8d9d80121484d39029db736f8bf9a64 Support direct fitting of weighted importance samples.
- e47868ef487f0ddb341498c5247bfd08778f280a Ensure that the new tests run even if the CLI test fails. Done by splitting the existing step in the ``check`` workflow job into to two steps.
- 256a6679e64994de6f4eac2df0f9310765b04ae8 Update Github action versions to avoid upcoming deprecation of Node.js v20-based actions.